### PR TITLE
Fix up for godot 4.0-stable

### DIFF
--- a/hydro_demo/hydro/art/OceanShader.tres
+++ b/hydro_demo/hydro/art/OceanShader.tres
@@ -1,15 +1,15 @@
 [gd_resource type="ShaderMaterial" load_steps=4 format=3 uid="uid://bxeqrusqusk2b"]
 
-[sub_resource type="Cubemap" id="Cubemap_6pgqq"]
+[ext_resource type="Texture2D" uid="uid://bjxkro274atb7" path="res://hydro/art/noise_tileable.png" id="1_4vjy1"]
 
 [sub_resource type="Shader" id="1"]
 code = "shader_type spatial;
-render_mode skip_vertex_transform, cull_front, unshaded;
+render_mode skip_vertex_transform, cull_front;
 
 uniform sampler2D waves;
 
 uniform sampler2D noise;
-uniform vec4 noise_params;
+uniform vec4 noise_params = vec4(0.0, 0.0, 0.0, 0.0);
 
 /*This uniform contains data that changes noise.
 X- The amplitude of the noise.
@@ -152,14 +152,14 @@ void fragment() {
 	ALBEDO = mix(refract_global, reflect_global, reflectiveness);
 }"
 
-[sub_resource type="ImageTexture" id="ImageTexture_v5tkn"]
+[sub_resource type="Cubemap" id="Cubemap_08y4y"]
 
 [resource]
 render_priority = 0
 shader = SubResource("1")
-environment = SubResource("Cubemap_6pgqq")
-noise_params = null
-project_bias = 1.2
-time_offset = 160.57
-water_color = Color(0.14902, 0.32549, 0.501961, 1)
-waves = SubResource("ImageTexture_v5tkn")
+shader_parameter/noise_params = Quaternion(0, 0, 0, 0)
+shader_parameter/water_color = Color(0, 0.917647, 1, 1)
+shader_parameter/project_bias = 1.2
+shader_parameter/time_offset = 3773.93
+shader_parameter/noise = ExtResource("1_4vjy1")
+shader_parameter/environment = SubResource("Cubemap_08y4y")

--- a/hydro_demo/hydro/art/noise_tileable.png.import
+++ b/hydro_demo/hydro/art/noise_tileable.png.import
@@ -4,23 +4,22 @@ importer="texture"
 type="CompressedTexture2D"
 uid="uid://bjxkro274atb7"
 path.s3tc="res://.godot/imported/noise_tileable.png-824310bbbf7142efded9034d8329d237.s3tc.ctex"
-path.etc2="res://.godot/imported/noise_tileable.png-824310bbbf7142efded9034d8329d237.etc2.ctex"
 metadata={
-"imported_formats": ["s3tc", "etc2"],
+"imported_formats": ["s3tc_bptc"],
 "vram_texture": true
 }
 
 [deps]
 
 source_file="res://hydro/art/noise_tileable.png"
-dest_files=["res://.godot/imported/noise_tileable.png-824310bbbf7142efded9034d8329d237.s3tc.ctex", "res://.godot/imported/noise_tileable.png-824310bbbf7142efded9034d8329d237.etc2.ctex"]
+dest_files=["res://.godot/imported/noise_tileable.png-824310bbbf7142efded9034d8329d237.s3tc.ctex"]
 
 [params]
 
 compress/mode=2
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=true

--- a/hydro_demo/hydro/core/MeshInstance.gd
+++ b/hydro_demo/hydro/core/MeshInstance.gd
@@ -1,7 +1,0 @@
-@tool
-extends MeshInstance3D
-
-func _process(delta):
-	var ocean = get_parent().get_node('Ocean')
-	
-	position = ocean.get_displace(Vector2())

--- a/hydro_demo/hydro/core/OceanEditor.gd
+++ b/hydro_demo/hydro/core/OceanEditor.gd
@@ -10,7 +10,7 @@ func _process(_delta):
 			"Seed": ocean.set_seed(hash($HFlowContainer/Settings/Seed/LineEdit.text))
 			"Amplitude": ocean.set_amplitude($HFlowContainer/Settings/Amplitude/HSlider.value)
 			"Wavelength": ocean.set_wavelength($HFlowContainer/Settings/Wavelength/HSlider.value)
-			"Steepness": ocean.set_steepness($SHFlowContainer/Settings/Steepness/HSlider.value)
+			"Steepness": ocean.set_steepness($HFlowContainer/Settings/Steepness/HSlider.value)
 			"WindDirectionX": wind_direction.x = $HFlowContainer/Settings/WindDirectionX/HSlider.value
 			"WindDirectionY": wind_direction.y = $HFlowContainer/Settings/WindDirectionY/HSlider.value
 			"WindAlign": ocean.set_wind_align($HFlowContainer/Settings/WindAlign/HSlider.value)

--- a/hydro_demo/hydro/core/ProjectedGrid.gd
+++ b/hydro_demo/hydro/core/ProjectedGrid.gd
@@ -32,29 +32,29 @@ var initialized = false
 
 var counter = 0.5
 var cube_cam = preload("res://hydro/core/CubeCamera.tscn")
-var cube_cam_inst;
+var cube_cam_inst
 
 var waves = []
 var waves_in_tex = ImageTexture.new()
 
 func _ready():
 	material_override = load("res://hydro/art/OceanShader.tres")
-	#TODO: fix mesh generation and shader
-#	mesh = ImmediateMesh.new()
-#
-#	for j in range(res):
-#		var y = j/res - 0.5
-#		var n_y = (j+1)/res - 0.5
-#		mesh.surface_begin(Mesh.PRIMITIVE_TRIANGLE_STRIP)
-#		for i in range(res):
-#			var x = i/res - 0.5						
-#			mesh.surface_add_vertex(Vector3(x*2, 0, -y*2))
-#			mesh.surface_add_vertex(Vector3(x*2, 0, -n_y*2))
-#		mesh.surface_end()
-#	mesh.surface_begin(Mesh.PRIMITIVE_POINTS)
-#	mesh.surface_add_vertex(-Vector3(1,1,1)*pow(2,32))
-#	mesh.surface_add_vertex(Vector3(1,1,1)*pow(2,32))
-#	mesh.surface_end()
+	#TODO: fix shader
+	mesh = ImmediateMesh.new()
+
+	for j in range(res):
+		var y = j/res - 0.5
+		var n_y = (j+1)/res - 0.5
+		mesh.surface_begin(Mesh.PRIMITIVE_TRIANGLE_STRIP)
+		for i in range(res):
+			var x = i/res - 0.5						
+			mesh.surface_add_vertex(Vector3(x*2, 0, -y*2))
+			mesh.surface_add_vertex(Vector3(x*2, 0, -n_y*2))
+		mesh.surface_end()
+	mesh.surface_begin(Mesh.PRIMITIVE_POINTS)
+	mesh.surface_add_vertex(-Vector3(1,1,1)*pow(2,32))
+	mesh.surface_add_vertex(Vector3(1,1,1)*pow(2,32))
+	mesh.surface_end()
 	
 	waves_in_tex = ImageTexture.new()
 	update_waves()
@@ -109,25 +109,25 @@ func set_speed(value):
 
 func set_noise_enabled(value):
 	noise_enabled = value
-	var old_noise_params = material_override.get_shader_uniform('noise_params')
-	old_noise_params.d = 1 if value else 0
+	var old_noise_params = material_override.get_shader_parameter('noise_params')
+	old_noise_params.w = 1 if value else 0
 	material_override.set_shader_parameter('noise_params', old_noise_params)
 
 func set_noise_amplitude(value):
 	noise_amplitude = value
-	var old_noise_params = material_override.get_shader_uniform('noise_params')
+	var old_noise_params = material_override.get_shader_parameter('noise_params')
 	old_noise_params.x = value
 	material_override.set_shader_parameter('noise_params', old_noise_params)
 
 func set_noise_frequency(value):
 	noise_frequency = value
-	var old_noise_params = material_override.get_shader_uniform('noise_params')
+	var old_noise_params = material_override.get_shader_parameter('noise_params')
 	old_noise_params.y = value
 	material_override.set_shader_parameter('noise_params', old_noise_params)
 
 func set_noise_speed(value):
 	noise_speed = value
-	var old_noise_params = material_override.get_shader_uniform('noise_params')
+	var old_noise_params = material_override.get_shader_parameter('noise_params')
 	old_noise_params.z = value
 	material_override.set_shader_parameter('noise_params', old_noise_params)
 
@@ -177,14 +177,13 @@ func update_waves():
 			'frequency': sqrt(0.098 * TAU/_wavelength)
 		})
 	#Put Waves in Texture..
-	var img = Image.new()
-	img.create(5, NUMBER_OF_WAVES, false, Image.FORMAT_RF)
+	var img = Image.create(5, NUMBER_OF_WAVES, false, Image.FORMAT_RF)
 	for i in range(NUMBER_OF_WAVES):
 		img.set_pixel(0, i, Color(waves[i]['amplitude'], 0,0,0))
 		img.set_pixel(1, i, Color(waves[i]['steepness'], 0,0,0))
 		img.set_pixel(2, i, Color(waves[i]['wind_directionX'], 0,0,0))
 		img.set_pixel(3, i, Color(waves[i]['wind_directionY'], 0,0,0))
 		img.set_pixel(4, i, Color(waves[i]['frequency'], 0,0,0))
-	waves_in_tex.create_from_image(img)
+	waves_in_tex = ImageTexture.create_from_image(img)
 	
 	material_override.set_shader_parameter('waves', waves_in_tex)

--- a/hydro_demo/hydro/scenes/Ocean3D.tscn
+++ b/hydro_demo/hydro/scenes/Ocean3D.tscn
@@ -43,18 +43,19 @@ sky = SubResource("Sky_cf5fw")
 [node name="Node" type="Node3D"]
 
 [node name="FirstPerson" parent="." instance=ExtResource("1")]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -0.0363367, 0.333668, 14.9742)
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 6, 15)
 motion_mode = 1
 
 [node name="DirectionalLight" type="DirectionalLight3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 0, 46.4912, 0)
 
 [node name="Ocean" type="MeshInstance3D" parent="."]
-visible = false
 material_override = ExtResource("2")
+transparency = 0.06
 script = ExtResource("3")
 
 [node name="WaterPlane" type="MeshInstance3D" parent="."]
+visible = false
 mesh = SubResource("PlaneMesh_kry3e")
 
 [node name="WaterArea3D" type="WaterArea3D" parent="."]

--- a/hydro_demo/hydro/uiux/Panel.tscn
+++ b/hydro_demo/hydro/uiux/Panel.tscn
@@ -14,66 +14,39 @@ offset_bottom = 40.0
 
 [node name="FreeLook" type="Label" parent="HFlowContainer"]
 layout_mode = 2
-offset_right = 254.0
-offset_bottom = 26.0
 theme_override_font_sizes/font_size = 16
 text = "Free look mode - press 'Q' to edit"
 
 [node name="EditMode" type="Label" parent="HFlowContainer"]
 visible = false
 layout_mode = 2
-anchors_preset = 5
-anchor_left = 0.5
-anchor_right = 0.5
-offset_left = 103.0
-offset_right = 354.0
-offset_bottom = 26.0
 text = "Edit mode - press 'Q' to free look"
 
 [node name="Settings" type="VBoxContainer" parent="HFlowContainer"]
 layout_mode = 2
-offset_top = 30.0
-offset_right = 138.0
-offset_bottom = 391.0
 
 [node name="Seed" type="HBoxContainer" parent="HFlowContainer/Settings"]
 layout_mode = 2
-offset_right = 138.0
-offset_bottom = 31.0
 
 [node name="Label" type="Label" parent="HFlowContainer/Settings/Seed"]
 layout_mode = 2
-offset_top = 2.0
-offset_right = 38.0
-offset_bottom = 28.0
 text = "Seed"
 
 [node name="LineEdit" type="LineEdit" parent="HFlowContainer/Settings/Seed"]
 layout_mode = 2
-offset_left = 42.0
-offset_right = 138.0
-offset_bottom = 31.0
 size_flags_horizontal = 3
 placeholder_text = "0"
 caret_blink = true
 
 [node name="Amplitude" type="HBoxContainer" parent="HFlowContainer/Settings"]
 layout_mode = 2
-offset_top = 35.0
-offset_right = 138.0
-offset_bottom = 61.0
 
 [node name="Label" type="Label" parent="HFlowContainer/Settings/Amplitude"]
 layout_mode = 2
-offset_right = 81.0
-offset_bottom = 26.0
 text = "Amplitude"
 
 [node name="HSlider" type="HSlider" parent="HFlowContainer/Settings/Amplitude"]
 layout_mode = 2
-offset_left = 85.0
-offset_right = 138.0
-offset_bottom = 16.0
 size_flags_horizontal = 3
 max_value = 1.0
 step = 0.001
@@ -81,21 +54,13 @@ value = 0.25
 
 [node name="Wavelength" type="HBoxContainer" parent="HFlowContainer/Settings"]
 layout_mode = 2
-offset_top = 65.0
-offset_right = 138.0
-offset_bottom = 91.0
 
 [node name="Label" type="Label" parent="HFlowContainer/Settings/Wavelength"]
 layout_mode = 2
-offset_right = 92.0
-offset_bottom = 26.0
 text = "Wavelength"
 
 [node name="HSlider" type="HSlider" parent="HFlowContainer/Settings/Wavelength"]
 layout_mode = 2
-offset_left = 96.0
-offset_right = 138.0
-offset_bottom = 16.0
 size_flags_horizontal = 3
 min_value = 20.0
 max_value = 128.0
@@ -104,21 +69,13 @@ value = 60.0
 
 [node name="Steepness" type="HBoxContainer" parent="HFlowContainer/Settings"]
 layout_mode = 2
-offset_top = 95.0
-offset_right = 138.0
-offset_bottom = 121.0
 
 [node name="Label" type="Label" parent="HFlowContainer/Settings/Steepness"]
 layout_mode = 2
-offset_right = 79.0
-offset_bottom = 26.0
 text = "Steepness"
 
 [node name="HSlider" type="HSlider" parent="HFlowContainer/Settings/Steepness"]
 layout_mode = 2
-offset_left = 83.0
-offset_right = 138.0
-offset_bottom = 16.0
 size_flags_horizontal = 3
 max_value = 1.0
 step = 0.001
@@ -126,21 +83,13 @@ value = 0.025
 
 [node name="WindDirectionX" type="HBoxContainer" parent="HFlowContainer/Settings"]
 layout_mode = 2
-offset_top = 125.0
-offset_right = 138.0
-offset_bottom = 151.0
 
 [node name="Label" type="Label" parent="HFlowContainer/Settings/WindDirectionX"]
 layout_mode = 2
-offset_right = 121.0
-offset_bottom = 26.0
 text = "WindDirectionX"
 
 [node name="HSlider" type="HSlider" parent="HFlowContainer/Settings/WindDirectionX"]
 layout_mode = 2
-offset_left = 125.0
-offset_right = 138.0
-offset_bottom = 16.0
 size_flags_horizontal = 3
 min_value = -1.0
 max_value = 1.0
@@ -149,21 +98,13 @@ value = 1.0
 
 [node name="WindDirectionY" type="HBoxContainer" parent="HFlowContainer/Settings"]
 layout_mode = 2
-offset_top = 155.0
-offset_right = 138.0
-offset_bottom = 181.0
 
 [node name="Label" type="Label" parent="HFlowContainer/Settings/WindDirectionY"]
 layout_mode = 2
-offset_right = 121.0
-offset_bottom = 26.0
 text = "WindDirectionY"
 
 [node name="HSlider" type="HSlider" parent="HFlowContainer/Settings/WindDirectionY"]
 layout_mode = 2
-offset_left = 125.0
-offset_right = 138.0
-offset_bottom = 16.0
 size_flags_horizontal = 3
 min_value = -1.0
 max_value = 1.0
@@ -171,42 +112,26 @@ step = 0.001
 
 [node name="WindAlign" type="HBoxContainer" parent="HFlowContainer/Settings"]
 layout_mode = 2
-offset_top = 185.0
-offset_right = 138.0
-offset_bottom = 211.0
 
 [node name="Label" type="Label" parent="HFlowContainer/Settings/WindAlign"]
 layout_mode = 2
-offset_right = 79.0
-offset_bottom = 26.0
 text = "WindAlign"
 
 [node name="HSlider" type="HSlider" parent="HFlowContainer/Settings/WindAlign"]
 layout_mode = 2
-offset_left = 83.0
-offset_right = 138.0
-offset_bottom = 16.0
 size_flags_horizontal = 3
 max_value = 1.0
 step = 0.001
 
 [node name="Speed" type="HBoxContainer" parent="HFlowContainer/Settings"]
 layout_mode = 2
-offset_top = 215.0
-offset_right = 138.0
-offset_bottom = 241.0
 
 [node name="Label" type="Label" parent="HFlowContainer/Settings/Speed"]
 layout_mode = 2
-offset_right = 48.0
-offset_bottom = 26.0
 text = "Speed"
 
 [node name="HSlider" type="HSlider" parent="HFlowContainer/Settings/Speed"]
 layout_mode = 2
-offset_left = 52.0
-offset_right = 138.0
-offset_bottom = 16.0
 size_flags_horizontal = 3
 max_value = 40.0
 step = 0.001
@@ -214,39 +139,23 @@ value = 10.0
 
 [node name="Noise" type="HBoxContainer" parent="HFlowContainer/Settings"]
 layout_mode = 2
-offset_top = 245.0
-offset_right = 138.0
-offset_bottom = 271.0
 
 [node name="Label" type="Label" parent="HFlowContainer/Settings/Noise"]
 layout_mode = 2
-offset_right = 110.0
-offset_bottom = 26.0
 text = "Noise Enabled"
 
 [node name="CheckBox" type="CheckBox" parent="HFlowContainer/Settings/Noise"]
 layout_mode = 2
-offset_left = 114.0
-offset_right = 138.0
-offset_bottom = 26.0
 
 [node name="NoiseAmp" type="HBoxContainer" parent="HFlowContainer/Settings"]
 layout_mode = 2
-offset_top = 275.0
-offset_right = 138.0
-offset_bottom = 301.0
 
 [node name="Label" type="Label" parent="HFlowContainer/Settings/NoiseAmp"]
 layout_mode = 2
-offset_right = 84.0
-offset_bottom = 26.0
 text = "Noise Amp"
 
 [node name="HSlider" type="HSlider" parent="HFlowContainer/Settings/NoiseAmp"]
 layout_mode = 2
-offset_left = 88.0
-offset_right = 138.0
-offset_bottom = 16.0
 size_flags_horizontal = 3
 max_value = 1.0
 step = 0.001
@@ -254,21 +163,13 @@ value = 0.28
 
 [node name="NoiseFreq" type="HBoxContainer" parent="HFlowContainer/Settings"]
 layout_mode = 2
-offset_top = 305.0
-offset_right = 138.0
-offset_bottom = 331.0
 
 [node name="Label" type="Label" parent="HFlowContainer/Settings/NoiseFreq"]
 layout_mode = 2
-offset_right = 83.0
-offset_bottom = 26.0
 text = "Noise Freq"
 
 [node name="HSlider" type="HSlider" parent="HFlowContainer/Settings/NoiseFreq"]
 layout_mode = 2
-offset_left = 87.0
-offset_right = 138.0
-offset_bottom = 16.0
 size_flags_horizontal = 3
 max_value = 1.0
 step = 0.01
@@ -276,21 +177,13 @@ value = 0.07
 
 [node name="NoiseSpeed" type="HBoxContainer" parent="HFlowContainer/Settings"]
 layout_mode = 2
-offset_top = 335.0
-offset_right = 138.0
-offset_bottom = 361.0
 
 [node name="Label" type="Label" parent="HFlowContainer/Settings/NoiseSpeed"]
 layout_mode = 2
-offset_right = 96.0
-offset_bottom = 26.0
 text = "Noise Speed"
 
 [node name="HSlider" type="HSlider" parent="HFlowContainer/Settings/NoiseSpeed"]
 layout_mode = 2
-offset_left = 100.0
-offset_right = 138.0
-offset_bottom = 16.0
 size_flags_horizontal = 3
 max_value = 1.0
 step = 0.01

--- a/hydro_demo/icon.png.import
+++ b/hydro_demo/icon.png.import
@@ -4,23 +4,22 @@ importer="texture"
 type="CompressedTexture2D"
 uid="uid://dbp0jqsp624po"
 path.s3tc="res://.godot/imported/icon.png-487276ed1e3a0c39cad0279d744ee560.s3tc.ctex"
-path.etc2="res://.godot/imported/icon.png-487276ed1e3a0c39cad0279d744ee560.etc2.ctex"
 metadata={
-"imported_formats": ["s3tc", "etc2"],
+"imported_formats": ["s3tc_bptc"],
 "vram_texture": true
 }
 
 [deps]
 
 source_file="res://icon.png"
-dest_files=["res://.godot/imported/icon.png-487276ed1e3a0c39cad0279d744ee560.s3tc.ctex", "res://.godot/imported/icon.png-487276ed1e3a0c39cad0279d744ee560.etc2.ctex"]
+dest_files=["res://.godot/imported/icon.png-487276ed1e3a0c39cad0279d744ee560.s3tc.ctex"]
 
 [params]
 
 compress/mode=2
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/hydro_demo/project.godot
+++ b/hydro_demo/project.godot
@@ -8,9 +8,6 @@
 
 config_version=5
 
-_global_script_classes=[]
-_global_script_class_icons={}
-
 [application]
 
 config/name="HydroSimpleDemo"
@@ -26,27 +23,27 @@ enabled=PackedStringArray()
 
 move_forward={
 "deadzone": 0.5,
-"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":87,"unicode":0,"echo":false,"script":null)
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":87,"key_label":0,"unicode":0,"echo":false,"script":null)
 ]
 }
 move_backward={
 "deadzone": 0.5,
-"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":83,"unicode":0,"echo":false,"script":null)
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":83,"key_label":0,"unicode":0,"echo":false,"script":null)
 ]
 }
 move_left={
 "deadzone": 0.5,
-"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":65,"unicode":0,"echo":false,"script":null)
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":65,"key_label":0,"unicode":0,"echo":false,"script":null)
 ]
 }
 move_right={
 "deadzone": 0.5,
-"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":68,"unicode":0,"echo":false,"script":null)
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":68,"key_label":0,"unicode":0,"echo":false,"script":null)
 ]
 }
 toggle_mouse={
 "deadzone": 0.5,
-"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":81,"unicode":0,"echo":false,"script":null)
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":81,"key_label":0,"unicode":0,"echo":false,"script":null)
 ]
 }
 

--- a/src/clippable_mesh.cpp
+++ b/src/clippable_mesh.cpp
@@ -104,7 +104,8 @@ void ClippableMesh::clip_to_plane_quadrant(
 		for (int j = 0; j < 3; j++)
 			current_face.vertex[j] = global_transform.xform(local_face.vertex[j]);
 
-		int quadrant = get_quadrant(center, current_face.get_median_point());
+		Vector3 face_median = (current_face.vertex[0] + current_face.vertex[1] + current_face.vertex[2]) / 3.0f;
+		int quadrant = get_quadrant(center, face_median);
 		const Plane &plane = planes[quadrant];
 
 		bool over[3];

--- a/src/hydro_rigid_body.cpp
+++ b/src/hydro_rigid_body.cpp
@@ -179,7 +179,7 @@ void HydroRigidBody::_body_state_changed(PhysicsDirectBodyState3D *p_state) {
 			get_linear_velocity() - m_water_area->get_flow_direction();
 	for (int i = 0; i < m_hull_mesh.clipped_face_count(); i++) {
 		const Face3 &f = m_hull_mesh.get_clipped_face(i);
-		Vector3 center_tri = f.get_median_point();
+		Vector3 center_tri = (f.vertex[0] + f.vertex[1] + f.vertex[2]) / 3.0f;
 		Vector3 normal = f.get_plane().normal;
 		float area = f.get_area();
 		int q = m_hull_mesh.get_quadrant(wave_center, center_tri);


### PR DESCRIPTION
Fixes for godot 4.0-stable:

`Vector3 Face3::get_median_point()` was removed by https://github.com/godotengine/godot/commit/c0083e431bb7bf66987f396cf9a62fa372d92fe9
Just drops in the old code inline.

Fixes up runtime errors preventing demo from running in 4.0-stable.
Gets basic waves working again.
Shading on waves is still broken, unknown why - cubemap generation seems to only return black textures.